### PR TITLE
README: Describe button to LED relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Simple tests to get started on Fomu, and to ensure the hardware functions.
 The canonical `Hello, world!` program for FPGAs is blinking an LED.  The `blink/` directory contains an implementation of this simple blinker that tests the following features:
 
 1. **48 MHz Oscillator** The oscillator drives the main timer.  There are options to use the internal RC oscillator within `blink.v`
-1. **RGB LED** The oscillator is divided down and sent to the green LED.  The Red and Blue LEDs are connected to switches
-1. **Switches 5 and 6** These switches have pullups enabled.  You can activate the Red and Green LEDs by pressing buttons 5 and 6.
+1. **RGB LED** The oscillator is divided down and sent to the green LED.  The Blue and Red LEDs are connected to switches
+1. **Switches 5 and 6** These switches have pullups enabled.  You can activate the Blue and Red LEDs by pressing buttons 5 and 6 respectively.
 
 ## Building
 


### PR DESCRIPTION
Update README to consistently describe how the button controlled LEDs are mapped to the buttons (appears to be true on EVT2 and EVT3: Green LED flashes from divided clock; Blue LED controlled by button 5, Red LED controlled by button 6).

Final change is just newline added to the file, auto-added by the editor.  Curiously the README file in the repo appears to have Unix-style line endings (LF only), but no final line ending (common to some Windows editors, but rare on Unix/Linux platforms); but other files have Windows style line endings.