### PR TITLE
Support EVT and non-EVT Fomu boards

### DIFF
--- a/blink/Makefile
+++ b/blink/Makefile
@@ -1,7 +1,8 @@
 PACKAGE   ?= $(notdir $(realpath .))
 TOP       ?= $(PACKAGE)
 
-GIT_VERSION := $(shell git describe --tags)
+# Currently GIT_VERSION is unusd and there are no tags, so skip calculating it
+#GIT_VERSION := $(shell git describe --tags)
 
 # Default programs
 NEXTPNR   ?= nextpnr-ice40
@@ -24,11 +25,13 @@ FOMU_REV  ?= evt3
 ifeq ($(FOMU_REV),evt3)
 PCF       ?= $(PCF_PATH)/fomu-evt3.pcf
 PKG       ?= sg48
+YOSYSFLAGS?= -D EVT=1 -D EVT3=1 -D HAVE_PMOD=1
 PNRFLAGS  ?= --up5k --package $(PKG)
 else
 ifeq ($(FOMU_REV),evt2)
 PCF       ?= $(PCF_PATH)/fomu-evt2.pcf
 PKG       ?= sg48
+YOSYSFLAGS?= -D EVT=1 -D EVT2=1 -D HAVE_PMOD=1
 PNRFLAGS  ?= --up5k --package $(PKG)
 else
 $(error Unrecognized FOMU_REV value. must be "evt2" or "evt3")
@@ -50,7 +53,7 @@ run: $(TARGET)
 
 $(BUILD_DIR)/$(PACKAGE).json: $(VSOURCES) | $(BUILD_DIR)
 	$(QUIET) echo " SYNTH    $@"
-	$(QUIET) $(YOSYS) -p 'synth_ice40 -top $(TOP) -json $@' $(PACKAGE).v
+	$(QUIET) $(YOSYS) $(YOSYSFLAGS) -p 'synth_ice40 -top $(TOP) -json $@' $(PACKAGE).v
 
 $(BUILD_DIR)/$(PACKAGE).asc: $(BUILD_DIR)/$(PACKAGE).json $(PCF)
 	$(QUIET) echo " PNR      $@"

--- a/blink/Makefile
+++ b/blink/Makefile
@@ -47,6 +47,7 @@ TARGET     = $(PACKAGE).bin
 CLEAN      = clean
 
 $(ALL): $(TARGET)
+	$(QUIET) echo "Built '$(PACKAGE)' for Fomu $(FOMU_REV)"
 
 run: $(TARGET)
 	fomu-flash -f $(TARGET)

--- a/blink/Makefile
+++ b/blink/Makefile
@@ -27,15 +27,18 @@ PCF       ?= $(PCF_PATH)/fomu-evt3.pcf
 PKG       ?= sg48
 YOSYSFLAGS?= -D EVT=1 -D EVT3=1 -D HAVE_PMOD=1
 PNRFLAGS  ?= --up5k --package $(PKG)
-else
-ifeq ($(FOMU_REV),evt2)
+else ifeq ($(FOMU_REV),evt2)
 PCF       ?= $(PCF_PATH)/fomu-evt2.pcf
 PKG       ?= sg48
 YOSYSFLAGS?= -D EVT=1 -D EVT2=1 -D HAVE_PMOD=1
 PNRFLAGS  ?= --up5k --package $(PKG)
+else ifeq ($(FOMU_REV),hacker)
+PCF       ?= $(PCF_PATH)/fomu-hacker.pcf
+PKG       ?= uwg30
+YOSYSFLAGS?= -D HACKER=1
+PNRFLAGS  ?= --up5k --package $(PKG)
 else
 $(error Unrecognized FOMU_REV value. must be "evt2" or "evt3")
-endif
 endif
 
 BUILD_DIR  = .build

--- a/blink/blink.v
+++ b/blink/blink.v
@@ -40,8 +40,8 @@
 `define BLUEPWM  RGB0PWM
 `define GREENPWM RGB1PWM
 `define REDPWM   RGB2PWM
-`define BUTTON1  pin1
-`define BUTTON2  pin4
+`define BUTTON1  user_1
+`define BUTTON2  user_4
 `endif
 
 module blink (
@@ -54,8 +54,8 @@ module blink (
     output pmod_3,
     output pmod_4,
 `endif
-    input `BUTTON1,    // Button 5 on EVT, pin1 on Hacker board
-    input `BUTTON2,    // Button 6 on EVT, pin4 on Hacker board
+    input `BUTTON1,    // Button 5 on EVT, short pin 1 - 2 on Hacker board
+    input `BUTTON2,    // Button 6 on EVT, short pin 3 - 4 on Hacker board
     input clki         // Clock
 );
 

--- a/blink/blink.v
+++ b/blink/blink.v
@@ -68,7 +68,7 @@ module blink (
 
     assign clk = clkosc;
 
-    // Latch first button state
+    // Connect first physical button, with pullup enabled
     wire button_1_pulled;
     SB_IO #(
         .PIN_TYPE(6'b 000001),
@@ -80,10 +80,10 @@ module blink (
         .D_IN_0(button_1_pulled),
     );
 
-    // Latch second button state
+    // Connect second physical button, with pullup enabled
     wire button_2_pulled;
     SB_IO #(
-        .PIN_TYPE(6'b 000000),
+        .PIN_TYPE(6'b 000001),
         .PULLUP(1'b 1)
     ) button_2_io (
         .PACKAGE_PIN(`BUTTON2),

--- a/blink/blink.v
+++ b/blink/blink.v
@@ -14,9 +14,9 @@
 //
 // On DVT / Hacker / Production Fomu boards:
 //
-// 1st LED colour - Blue  - controlled by pressing connecting pin 1 to 2
+// 1st LED colour - Blue  - turn on by connecting pin 1 to pin 2
 // 2nd LED colour - Green - controlled by clock (blinking)
-// 3rd LED colour - Red   - controlled by pressing connecting pin 3 to 4
+// 3rd LED colour - Red   - turn on by connecting pin 3 to pin 4
 //
 // We use `defines to handle these two cases, because the SB_RGBA_DRV
 // iCE40UP5K hard macro is unable to do RGBn to output pin mapping internally

--- a/blink/blink.v
+++ b/blink/blink.v
@@ -36,9 +36,9 @@
 `endif
 
 module blink (
-    output led_r,      // Red LED
-    output led_g,      // Green LED
-    output led_b,      // Blue LED
+    output rgb0,       // SB_RGBA_DRV external pins
+    output rgb1,
+    output rgb2,
 `ifdef HAVE_PMOD
     output pmod_1,     // PMOD ouput connector (on EVT boards)
     output pmod_2,
@@ -135,9 +135,9 @@ module blink (
         .`BLUEPWM(~user_5_pulled),     // Blue
         .`REDPWM(~user_6_pulled),      // Red
         .`GREENPWM(outcnt[4]),         // Green
-        .RGB0(led_b),
-        .RGB1(led_r),
-        .RGB2(led_g)
+        .RGB0(rgb0),
+        .RGB1(rgb1),
+        .RGB2(rgb2)
     );
 
     // Parameters from iCE40 UltraPlus LED Driver Usage Guide, pages 19-20

--- a/pcf/fomu-evt2.pcf
+++ b/pcf/fomu-evt2.pcf
@@ -1,6 +1,6 @@
-set_io led_b 39
-set_io led_r 40
-set_io led_g 41
+set_io rgb0 39
+set_io rgb1 40
+set_io rgb2 41
 set_io pmoda_1 25
 set_io pmoda_2 26
 set_io pmoda_3 27

--- a/pcf/fomu-evt3.pcf
+++ b/pcf/fomu-evt3.pcf
@@ -1,6 +1,6 @@
-set_io led_b 39
-set_io led_r 40
-set_io led_g 41
+set_io rgb0 39
+set_io rgb1 40
+set_io rgb2 41
 set_io pmod_1 28
 set_io pmod_2 27
 set_io pmod_3 26

--- a/pcf/fomu-hacker.pcf
+++ b/pcf/fomu-hacker.pcf
@@ -1,0 +1,14 @@
+set_io rgb0 A5
+set_io rgb1 B5
+set_io rgb2 C5
+set_io clki F5
+set_io spi_mosi F1
+set_io spi_miso E1
+set_io spi_clk D1
+set_io spi_cs C1
+set_io pin1 F4
+set_io pin2 E5
+set_io pin3 E4
+set_io pin4 F2
+set_io usb_dn A2
+set_io usb_dp A4

--- a/pcf/fomu-hacker.pcf
+++ b/pcf/fomu-hacker.pcf
@@ -6,9 +6,9 @@ set_io spi_mosi F1
 set_io spi_miso E1
 set_io spi_clk D1
 set_io spi_cs C1
-set_io pin1 F4
-set_io pin2 E5
-set_io pin3 E4
-set_io pin4 F2
+set_io user_1 F4
+set_io user_2 E5
+set_io user_3 E4
+set_io user_4 F2
 set_io usb_dn A2
 set_io usb_dp A4


### PR DESCRIPTION
Update `blink` and `pcf` to attempt to support both EVT2/EVT3 boards (which have one RGBn/LED colour mapping) and other Fomu boards (eg, Hacker board) in the same blink example, using `` `ifdef`` and `` `define`` to smooth over the inconsistencies while sticking with a single `blink.v` and single module for a simple test case.

Draft `pcf/fomu-hacker.pcf` made up from [Fomu Hacker schematic PDF](https://raw.githubusercontent.com/im-tomu/fomu-hardware/master/hacker/releases/v0.0-19-g154fecc/schematic.pdf).

Tested on EVT2/EVT3.  "It compiles" on Fomu Hacker boards, as I do not have one of them.