### PR TITLE
Add USB DP pull up to fomu hacker pdc

### DIFF
--- a/pcf/fomu-hacker.pcf
+++ b/pcf/fomu-hacker.pcf
@@ -12,3 +12,4 @@ set_io user_3 E4
 set_io user_4 F2
 set_io usb_dn A2
 set_io usb_dp A4
+set_io usb_dp_pu D5


### PR DESCRIPTION
Fixes

```
ERROR: IO 'usb_dp_pu' is unconstrained in PCF (override this error with --pcf-allow-unconstrained)
```

when building blink for fomu hacker target
```
make FOMU_REV=hacker
```
at pnr stage.

Could not test on hardware yet because after DFU download the board goes dark